### PR TITLE
LoadIndex should start read from current offset

### DIFF
--- a/range_scanner.go
+++ b/range_scanner.go
@@ -15,9 +15,12 @@ type Index struct {
 
 // LoadIndex scans the file and parse chunkOffsets, chunkLens, and len.
 func LoadIndex(r io.ReadSeeker) (*Index, error) {
+	offset, e := r.Seek(0, io.SeekCurrent)
+	if e != nil {
+		return nil, e
+	}
+
 	f := &Index{}
-	offset := int64(0)
-	var e error
 	var hdr *Header
 
 	for {


### PR DESCRIPTION
To support incremental index and record loading